### PR TITLE
Fix Notch Cost Overwrite; Fix Grimmchild Spawn Hard-Lock

### DIFF
--- a/Menus/GrimmChildMenu.cs
+++ b/Menus/GrimmChildMenu.cs
@@ -5,25 +5,39 @@ namespace RandomCompanions
     {
         internal static Menu GrimmChildMenu;
         internal static Menu PrepareGrimmChildMenu(){
-            return new Menu("Grimmchild Settngs",new Element[]{
-
+            return new Menu("Grimmchild Settings",new Element[]{
                 new HorizontalOption(
-                    "Free GrimmChild", "Make Affected charms free.",
+                    "Start With Grimmchild", "Automatically give charm at start of game.",
                     new string[] { "Disabled", "Enabled" },
                     (setting) => {
                          if((setting == 1)){
-                            RandomCompanions.Settings.GrimmChildcharmCost = 0;
+                            RandomCompanions.Settings.GrimmChildCharmStart = true;
                         } else {
-                            RandomCompanions.Settings.GrimmChildcharmCost = defaultSettings.WeaverlingcharmCost;
+                            RandomCompanions.Settings.GrimmChildCharmStart = false;
+                        }
+                    },
+                    () => {
+                         return RandomCompanions.Settings.GrimmChildCharmStart ? 1 : 0;
+                    },
+                    Id:"AutoGrimmChild"),
+
+                new HorizontalOption(
+                    "Free Grimmchild", "Make charm free to equip.",
+                    new string[] { "Disabled", "Enabled" },
+                    (setting) => {
+                         if((setting == 1)){
+                            RandomCompanions.Settings.GrimmChildCharmFree = true;
+                        } else {
+                            RandomCompanions.Settings.GrimmChildCharmFree = false;
                         } 
                     },
                     () => {
-                         return RandomCompanions.Settings.GrimmChildcharmCost == 0 ? 1 : 0;
+                         return RandomCompanions.Settings.GrimmChildCharmFree ? 1 : 0;
                     },
                     Id:"FreeGrimmChild"),
 
                 new CustomSlider(
-                    "Max GrimmChild Count",
+                    "Max Grimmchild Count",
                     (f)=>{
                         RandomCompanions.Settings.GrimmChildMaxCount = (int)f;
                     },
@@ -32,7 +46,7 @@ namespace RandomCompanions
                     Id:"GrimmChildCount"),
 
                 new HorizontalOption(
-                    "Multi-Level GrimmChilden", "Cycle through all levels of GrimmChild",
+                    "Multi-Level Grimmchildren", "Cycle through all levels of Grimmchild",
                     new string[] { "Disabled", "Enabled" },
                     (setting) => {
                          if((setting == 1)){

--- a/Menus/HatchlingsMenu.cs
+++ b/Menus/HatchlingsMenu.cs
@@ -5,24 +5,39 @@ namespace RandomCompanions
     {
         internal static Menu HatchlingMenu;
         internal static Menu PrepareHatchlingsMenu(){
-            return new Menu("Hatchling Settngs",new Element[]{
+            return new Menu("Hatchling Settings",new Element[]{
                 new HorizontalOption(
-                    "Free Hatchlings", "Make Affected charms free.",
+                    "Start With Glowing Womb", "Automatically give charm at start of game.",
                     new string[] { "Disabled", "Enabled" },
                     (setting) => {
                          if((setting == 1)){
-                            RandomCompanions.Settings.HatchlingcharmCost = 0;
+                            RandomCompanions.Settings.HatchlingCharmStart = true;
                         } else {
-                            RandomCompanions.Settings.HatchlingcharmCost = defaultSettings.HatchlingcharmCost;
+                            RandomCompanions.Settings.HatchlingCharmStart = false;
+                        }
+                    },
+                    () => {
+                         return RandomCompanions.Settings.HatchlingCharmStart ? 1 : 0;
+                    },
+                    Id:"AutoHatchings"),
+
+                new HorizontalOption(
+                    "Free Glowing Womb", "Make charm free to equip.",
+                    new string[] { "Disabled", "Enabled" },
+                    (setting) => {
+                         if((setting == 1)){
+                            RandomCompanions.Settings.HatchlingCharmFree = true;
+                        } else {
+                            RandomCompanions.Settings.HatchlingCharmFree = false;
                         } 
                     },
                     () => {
-                        return RandomCompanions.Settings.HatchlingcharmCost == 0 ? 1 : 0;
+                        return RandomCompanions.Settings.HatchlingCharmFree ? 1 : 0;
                     },
                     Id:"FreeHatchlings"),
 
                 new HorizontalOption(
-                    "Quick Spawn", "Remove Delays when spawning hatchlings.",
+                    "Quick Spawn", "Remove delays when spawning hatchlings.",
                     new string[] { "Disabled", "Enabled" },
                     (setting) => {
                          if((setting == 1)){

--- a/Menus/WeaverlingsMenu.cs
+++ b/Menus/WeaverlingsMenu.cs
@@ -5,21 +5,37 @@ namespace RandomCompanions
     {
         internal static Menu WeaverlingsMenu;
         internal static Menu PrepareWeaverlingsMenu(){
-            return new Menu("Weaverlings Settngs",new Element[]{
+            return new Menu("Weaverlings Settings",new Element[]{
                 new HorizontalOption(
-                    "Free Weaverlings", "Make Affected charms free.",
+                    "Start With Weaversong", "Automatically give charm at start of game.",
                     new string[] { "Disabled", "Enabled" },
                     (setting) => {
                          if((setting == 1)){
-                            RandomCompanions.Settings.WeaverlingcharmCost = 0;
+                            RandomCompanions.Settings.WeaverlingCharmStart = true;
                         } else {
-                            RandomCompanions.Settings.WeaverlingcharmCost = defaultSettings.WeaverlingcharmCost;
+                            RandomCompanions.Settings.WeaverlingCharmStart = false;
+                        }
+                    },
+                    () => {
+                         return RandomCompanions.Settings.WeaverlingCharmStart ? 1 : 0;
+                    },
+                    Id:"AutoWeaverlings"),
+
+                new HorizontalOption(
+                    "Free Weaversong", "Make charm free to equip.",
+                    new string[] { "Disabled", "Enabled" },
+                    (setting) => {
+                         if((setting == 1)){
+                            RandomCompanions.Settings.WeaverlingCharmFree = true;
+                        } else {
+                            RandomCompanions.Settings.WeaverlingCharmFree = false;
                         } 
                     },
                     () => {
-                         return RandomCompanions.Settings.WeaverlingcharmCost == 0 ? 1 : 0;
+                         return RandomCompanions.Settings.WeaverlingCharmFree ? 1 : 0;
                     },
                     Id:"FreeWeaverlings"),
+
                 new CustomSlider(
                     "Max Weaverling Count",
                     (f)=>{

--- a/RandomCompanions.cs
+++ b/RandomCompanions.cs
@@ -199,23 +199,24 @@ namespace RandomCompanions
                 });
             }
         }
-        private bool ModifyCharmGot(string name,bool orig){
+        private bool ModifyCharmGot(string name, bool orig)
+        {
             if (name == nameof(PlayerData.gotCharm_22))
-                return Settings.HatchlingcharmCost == 0 || orig;
+                return Settings.HatchlingCharmStart || orig;
             if (name == nameof(PlayerData.gotCharm_39))
-                return Settings.WeaverlingcharmCost == 0 || orig;
+                return Settings.WeaverlingCharmStart || orig;
             if (name == nameof(PlayerData.gotCharm_40))
-                return Settings.GrimmChildcharmCost == 0 || orig;
+                return Settings.GrimmChildCharmStart || orig;
             return orig;
         }
         private int ModifyCharmCost(string intName, int orig)
         {
             if (intName == nameof(PlayerData.charmCost_22))
-                return Math.Abs(Settings.HatchlingcharmCost);
+                return Settings.HatchlingCharmFree ? 0 : orig;
             if (intName == nameof(PlayerData.charmCost_39))
-                return Math.Abs(Settings.WeaverlingcharmCost);
+                return Settings.WeaverlingCharmFree ? 0 : orig;
             if (intName == nameof(PlayerData.charmCost_40))
-                return Math.Abs(Settings.GrimmChildcharmCost);
+                return Settings.GrimmChildCharmFree ? 0 : orig;
             return orig;
         }
 

--- a/RandomCompanions.cs
+++ b/RandomCompanions.cs
@@ -118,7 +118,12 @@ namespace RandomCompanions
             var minValue = 1;
             float attempt = 2;
             var tries = 5;
-            while(gcOffsets.Contains(attempt) || tries < 0){
+            if (gcOffsets.Count == Settings.GrimmChildMaxCount)
+            {
+                gcOffsets.RemoveAt(0);
+            }
+            while (gcOffsets.Contains(attempt) || tries > 0)
+            {
                 attempt = (float)Math.Round((rng.NextDouble() * (maxValue) + minValue) * 2);
                 tries--;
             }
@@ -154,7 +159,7 @@ namespace RandomCompanions
                             self.GetAction<DistanceFlySmooth>("Follow",11).target = targ;
                         }
                     });
-                    
+
                 }
             }
 
@@ -192,7 +197,7 @@ namespace RandomCompanions
                                 j = 3;
                             }else if(j == 1){
                                 p1.OnEnter();
-                                j = 3;
+                                j = 2;
                             }
                         }
                     }

--- a/Settings.cs
+++ b/Settings.cs
@@ -4,13 +4,16 @@
     {
         public bool attackOption = true;
         public int HatchlingMaxCount = 4;
-        public int HatchlingcharmCost = 2;
+        public bool HatchlingCharmFree = false;
+        public bool HatchlingCharmStart = false;
         public int HatchlingSoulCost = 8;
         public float HatchlingSpawnTime = 4.0f;
         public int WeaverlingMaxCount = 3;
-        public int WeaverlingcharmCost = 2;
+        public bool WeaverlingCharmFree = false;
+        public bool WeaverlingCharmStart = false;
         public int GrimmChildMaxCount = 1;
-        public int GrimmChildcharmCost = 2;
+        public bool GrimmChildCharmFree = false;
+        public bool GrimmChildCharmStart = false;
         public bool GrimmChildMultiLevel = true;
 
     }


### PR DESCRIPTION
- Notch cost is only overridden to free if the option to make the charm free is set under the mod options; otherwise it uses whatever notch cost the game originally presented to the mod.
- Separate menu options are now available for providing the companion charm at the start of a game as well as for making the charm free (previously the mod assume if you made the charm cost no notches, you were supposed to start with the charm).
- A hard-lock involving the determination of Grimmchild spawning has been fixed.
- Improved generation of Grimmchild target offsets to avoid overlapping Grimmchilds has been implemented.
- Minor fix for Weaverling spawns where a specific value of a counting index was being skipped.